### PR TITLE
Fix compile on linux gcc 3.7.2. Change the name of the template paramete...

### DIFF
--- a/boolinq/boolinq.h
+++ b/boolinq/boolinq.h
@@ -713,8 +713,8 @@ namespace boolinq
             return unbits(direction).unbytes<TRet>(bytesDirection);
         }
 
-        template<typename TE>
-        friend std::ostream & operator << (std::ostream & stream, LinqObj<TE> linq);
+        template<typename TE_>
+        friend std::ostream & operator << (std::ostream & stream, LinqObj<TE_> linq);
     };
 
     template<typename TE>


### PR DESCRIPTION
...r to avoid name clash

GCC doesn't like using the same named parameter with a nested template, where it is logically a different template paramter.
This is my first go at a github push. Hope it is okay and I did the correct steps.
