### PR TITLE
CMakeList: make project build with MSVC

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -28,6 +28,5 @@ ADD_EXECUTABLE (
 TARGET_LINK_LIBRARIES (
     boolinqbenchmark
     gtest
-    pthread
     benchmark
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,7 +61,6 @@ TARGET_LINK_LIBRARIES (
     boolinqtest
     gtest_main
     #gcov
-    pthread
 )
 ENABLE_TESTING ()
 ADD_TEST (BoolinqTest boolinqtest)


### PR DESCRIPTION
Removing pthread from TARGET_LINK_LIBRARIES of test and benchmark
subdirectories
 * makes it possible to compile the prject in MS Visual Studio
 * does not impact building with gcc