### PR TITLE
Fix link to Travis CI builds for k06a/boolinq project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # boolinq 3.0
 
-[![CI Status](https://travis-ci.com/k06a/boolinq.svg?branch=master)](https://travis-ci.com/k06a/boolinq)
+[![CI Status](https://travis-ci.com/k06a/boolinq.svg?branch=master)](https://app.travis-ci.com/github/k06a/boolinq)
 [![Coverage Status](https://coveralls.io/repos/github/k06a/boolinq/badge.svg?branch=master)](https://coveralls.io/github/k06a/boolinq?branch=master)
 
 Super tiny C++11 single-file header-only LINQ template library


### PR DESCRIPTION
Currently the link takes you to a non-existent page with a 404 error.

I hope this fix helps. Please consider [tipping me on Gitcoin](https://gitcoin.co/tip?username=helr441), thank you.