### PR TITLE
Generate gcov with llvm-cov for clang builds and skip gcov in cpp-coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,4 +82,14 @@ script:
   - ./bench/boolinq-bench
   
 after_success:
-  - coveralls --root .. --include include --gcov-options '\-lp' --gcov $GCOV --verbose
+  - case "$CC" in
+        clang-*)
+          echo "Processing llvm coverage with llvm-cov, bypass gcov in cpp-coveralls and submitting";
+          find test/CMakeFiles/boolinq-test.dir/ -name '*.cpp.o' | xargs llvm-cov gcov -lp ;
+          coveralls --root .. --include include --no-gcov --verbose
+          ;;
+        *)
+          echo "Processing with gcov in cpp-coveralls and submitting";
+          coveralls --root .. --include include --gcov-options '\-lp' --gcov $GCOV --verbose
+          ;;
+    esac


### PR DESCRIPTION
Previously coverage wasn't captured for clang builds and reported at 0%. With this change, we now get some numbers.

As a corollary, we now see nice coverage numbers for the overall build matrix instead of a miserable (and misleading) 0%!