### PR TITLE
Cleanup CMakeLists.txt files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,17 @@ ipch
 nbproject
 .idea
 cmake-build-debug
+CMakeCache.txt
+CMakeFiles/
+DartConfiguration.tcl
+CTestTestfile.cmake
+Makefile
+Testing/
+cmake_install.cmake
+boolinq-bench
+boolinq-test
+/externals/benchmark/*
+/externals/googletest/*
+cppcheck.report
+coverage/
+coverage.info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 # Common variables.
 CMAKE_MINIMUM_REQUIRED (VERSION 3.0)
-if (POLICY CMP0048)
-    cmake_policy(SET CMP0048 NEW)
-endif()
 PROJECT (boolinq VERSION 3.0.0 LANGUAGES CXX)
 INCLUDE(Dart)
 
@@ -11,18 +8,11 @@ SET (CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS} -O0 -ggdb3 -DDEBUG")
 SET (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3")
 
 
-# Boolinq source code.
-SET (
-    Boolinq_INCLUDES
-    ${PROJECT_SOURCE_DIR}/boolinq/boolinq.h
-)
-
-
 # Static code analyse.
 SET (CppCheck_REPORT ${PROJECT_BINARY_DIR}/cppcheck.report)
 ADD_CUSTOM_COMMAND (
     OUTPUT  ${CppCheck_REPORT}
-    COMMAND cppcheck ${Boolinq_INCLUDES} --enable=all --force --inconclusive &>cppcheck.report
+    COMMAND cppcheck ${PROJECT_SOURCE_DIR}/boolinq/boolinq.h --enable=all --force --inconclusive &>cppcheck.report
 )
 ADD_CUSTOM_TARGET  (cppcheck DEPENDS ${CppCheck_REPORT})
 SET_DIRECTORY_PROPERTIES (PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${CppCheck_REPORT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ SET (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3")
 SET (CppCheck_REPORT ${PROJECT_BINARY_DIR}/cppcheck.report)
 ADD_CUSTOM_COMMAND (
     OUTPUT  ${CppCheck_REPORT}
-    COMMAND cppcheck ${PROJECT_SOURCE_DIR}/boolinq/boolinq.h --enable=all --force --inconclusive &>cppcheck.report
+    COMMAND cppcheck ${PROJECT_SOURCE_DIR}/imclude/boolinq/boolinq.h --enable=all --force --inconclusive &>cppcheck.report
 )
 ADD_CUSTOM_TARGET  (cppcheck DEPENDS ${CppCheck_REPORT})
 SET_DIRECTORY_PROPERTIES (PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${CppCheck_REPORT})

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -3,12 +3,9 @@
 SET (CMAKE_CXX_STANDARD 11)
 SET (CMAKE_CXX_STANDARD_REQUIRED ON)
 SET (TARGET "${PROJECT_NAME}-bench" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wmissing-include-dirs -Wfloat-equal -Wshadow")
-SET (TARGET "${PROJECT_NAME}-bench" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wdouble-promotion -Winit-self -Weffc++")
-SET (TARGET "${PROJECT_NAME}-bench" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual -Wsign-promo")
-SET (TARGET "${PROJECT_NAME}-bench" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wvla -Winvalid-pch -Winline -Wredundant-decls")
-SET (TARGET "${PROJECT_NAME}-bench" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wcast-align")
-SET (TARGET "${PROJECT_NAME}-bench" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wcast-qual -Wpointer-arith")
-SET (TARGET "${PROJECT_NAME}-bench" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast")
+SET (TARGET "${PROJECT_NAME}-bench" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wdouble-promotion -Weffc++ -Woverloaded-virtual -Wsign-promo")
+SET (TARGET "${PROJECT_NAME}-bench" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wvla -Winvalid-pch -Winline -Wredundant-decls -Wcast-align")
+SET (TARGET "${PROJECT_NAME}-bench" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wcast-qual -Wpointer-arith -Wold-style-cast")
 
 
 INCLUDE_DIRECTORIES (${PROJECT_SOURCE_DIR}/include/boolinq)
@@ -17,13 +14,9 @@ INCLUDE_DIRECTORIES (${CMAKE_BINARY_DIR}/googletest-src/googletest/include)
 
 
 # Benchmarks.
-SET (
-    BoolinqBench_SOURCES
-    ${PROJECT_SOURCE_DIR}/bench/SpeedTest.cpp
-)
 ADD_EXECUTABLE (
     "${PROJECT_NAME}-bench"
-    ${BoolinqBench_SOURCES}
+    ${PROJECT_SOURCE_DIR}/bench/SpeedTest.cpp
 )
 TARGET_LINK_LIBRARIES (
     "${PROJECT_NAME}-bench"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,15 +2,10 @@
 SET (CMAKE_CXX_STANDARD 11)
 SET (CMAKE_CXX_STANDARD_REQUIRED ON)
 SET (TARGET "${PROJECT_NAME}-test" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wmissing-include-dirs -Wfloat-equal -Wshadow")
-SET (TARGET "${PROJECT_NAME}-test" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wdouble-promotion -Winit-self -Weffc++ ")
-SET (TARGET "${PROJECT_NAME}-test" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual -Wsign-promo")
-SET (TARGET "${PROJECT_NAME}-test" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wvla -Winvalid-pch -Winline -Wredundant-decls")
-SET (TARGET "${PROJECT_NAME}-test" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wcast-align")
-SET (TARGET "${PROJECT_NAME}-test" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wcast-qual -Wpointer-arith")
-SET (TARGET "${PROJECT_NAME}-test" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast")
+SET (TARGET "${PROJECT_NAME}-test" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wdouble-promotion -Weffc++ -Woverloaded-virtual -Wsign-promo")
+SET (TARGET "${PROJECT_NAME}-test" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wvla -Winvalid-pch -Winline -Wredundant-decls -Wcast-align")
+SET (TARGET "${PROJECT_NAME}-test" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wcast-qual -Wpointer-arith -Wold-style-cast")
 SET (TARGET "${PROJECT_NAME}-test" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
-SET (CMAKE_SHARED_LINKER_FLAGS "-fprofile-arcs -ftest-coverage")
-SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
 
 
 INCLUDE_DIRECTORIES (${PROJECT_SOURCE_DIR}/include/boolinq)
@@ -71,23 +66,18 @@ TARGET_LINK_LIBRARIES (
 ENABLE_TESTING ()
 ADD_TEST (BoolinqTest "${PROJECT_NAME}-test")
 
-
 # Test coverage report.
 SET (Coverage_REPORT ${PROJECT_BINARY_DIR}/coverage.info)
 SET (Coverage_DIR    ${PROJECT_BINARY_DIR}/coverage)
 ADD_CUSTOM_COMMAND (
     OUTPUT  ${Coverage_REPORT}
-    COMMAND lcov -q -c -f -b . -d ${PROJECT_BINARY_DIR}/boolinq -o ${Coverage_REPORT}
-    COMMAND lcov -e ${Coverage_REPORT} '${PROJECT_SOURCE_DIR}/boolinq/*' -o ${Coverage_REPORT}
+    COMMAND lcov -q -c -f -b . -d ${PROJECT_BINARY_DIR}/ -o ${Coverage_REPORT}
+    COMMAND lcov -e ${Coverage_REPORT} '${PROJECT_SOURCE_DIR}/*' -o ${Coverage_REPORT}
     COMMAND genhtml ${Coverage_REPORT} --legend --demangle-cpp -f -q -o ${Coverage_DIR}
     DEPENDS "${PROJECT_NAME}-test"
 )
 ADD_CUSTOM_TARGET (coverage DEPENDS ${Coverage_REPORT})
-# FIXME: Doesn't work correctly (require explicit call cmake when files appear).
-FILE (GLOB_RECURSE Coverage_GCNO ${PROJECT_BINARY_DIR}/*.gcno)
-FILE (GLOB_RECURSE Coverage_GCDA ${PROJECT_BINARY_DIR}/*.gcda)
 LIST (APPEND Coverage_DATA "${Coverage_REPORT}")
 LIST (APPEND Coverage_DATA "${Coverage_DIR}")
-LIST (APPEND Coverage_DATA "${Coverage_GCNO}")
-LIST (APPEND Coverage_DATA "${Coverage_GCDA}")
+LIST (APPEND Coverage_DATA "${PROJECT_BINARY_DIR}/test/CMakeFiles/boolinq-test.dir")
 SET_DIRECTORY_PROPERTIES (PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${Coverage_DATA}")


### PR DESCRIPTION
It was hard to cleanup these files because they originally were simple and contained almost nothing that could be removed. I removed some SET declarations that are used only once, one -W option that appeared to be covered by -Wall, that's all - it's really impossible to make these files more simple. Also I fixed an error in 'make coverage' (wrong directories) and an issue mentioned in test/CMakeLists.txt.
Also I dared to change .gitignore to include all the generated stuff there. I hope it would be an useful change.