### PR TITLE
Fix result_of deprecation with compatibility

### DIFF
--- a/include/boolinq/boolinq.h
+++ b/include/boolinq/boolinq.h
@@ -20,8 +20,13 @@
 #if (defined(_MSC_VER) && _MSVC_LANG >= 202002L) || __cplusplus >= 202002L
 namespace std
 {
-	template<typename _Callable, typename ..._Args>
-	using result_of = std::invoke_result<_Callable, _Args...>;
+    template<typename _Callable>
+    struct result_of;
+
+    template<typename _Callable, typename... _Args>
+    struct result_of<_Callable(_Args...)> {
+        typedef std::invoke_result<_Callable, _Args...>::type type;
+    };
 }
 #endif
 

--- a/include/boolinq/boolinq.h
+++ b/include/boolinq/boolinq.h
@@ -14,25 +14,20 @@
 #include <set>
 #include <unordered_set>
 
-//
+namespace boolinq {
 
-// The result_of was deprecated since C++20, so redefine it using invoke_result
-#if (defined(_MSC_VER) && _MSVC_LANG >= 202002L) || __cplusplus >= 202002L
-namespace std
-{
+    //
+
+    // The result_of was removed since C++20 by not all but some compilers. For the sake of compatibility, use own define but of course not in std namespace.
     template<typename _Callable>
     struct result_of;
 
     template<typename _Callable, typename... _Args>
     struct result_of<_Callable(_Args...)> {
-        typedef std::invoke_result<_Callable, _Args...>::type type;
+        typedef decltype(std::declval<_Callable>()(std::declval<_Args>()...)) type;
     };
-}
-#endif
 
-//
-
-namespace boolinq {
+    //
 
     struct LinqEndException {};
 
@@ -210,7 +205,7 @@ namespace boolinq {
             );
         }
 
-        template<typename F, typename _TRet = typename std::result_of<F(T, int)>::type>
+        template<typename F, typename _TRet = typename result_of<F(T, int)>::type>
         Linq<std::tuple<Linq<S, T>, int>, _TRet> select_i(F apply) const
         {
             return Linq<std::tuple<Linq<S, T>, int>, _TRet>(
@@ -224,7 +219,7 @@ namespace boolinq {
             );
         }
 
-        template<typename F, typename _TRet = typename std::result_of<F(T)>::type>
+        template<typename F, typename _TRet = typename result_of<F(T)>::type>
         Linq<std::tuple<Linq<S, T>, int>, _TRet> select(F apply) const
         {
             return select_i([apply](T value, int /*index*/) { return apply(value); });
@@ -259,7 +254,7 @@ namespace boolinq {
 
         template<
             typename F,
-            typename _TRet = typename std::result_of<F(T, int)>::type,
+            typename _TRet = typename result_of<F(T, int)>::type,
             typename _TRetVal = typename _TRet::value_type
         >
         Linq<std::tuple<Linq<S, T>, _TRet, int, bool>, _TRetVal> selectMany_i(F apply) const
@@ -290,7 +285,7 @@ namespace boolinq {
 
         template<
             typename F,
-            typename _TRet = typename std::result_of<F(T)>::type,
+            typename _TRet = typename result_of<F(T)>::type,
             typename _TRetVal = typename _TRet::value_type
         >
         Linq<std::tuple<Linq<S, T>, _TRet, int, bool>, _TRetVal> selectMany(F apply) const
@@ -300,7 +295,7 @@ namespace boolinq {
 
         template<
             typename F,
-            typename _TKey = typename std::result_of<F(T)>::type,
+            typename _TKey = typename result_of<F(T)>::type,
             typename _TValue = Linq<std::tuple<Linq<S, T>, int>, T> // where(predicate)
         >
         Linq<std::tuple<Linq<S, T>, Linq<S, T>, std::unordered_set<_TKey> >, std::pair<_TKey, _TValue> > groupBy(F apply) const
@@ -324,7 +319,7 @@ namespace boolinq {
             );
         }
 
-        template<typename F, typename _TRet = typename std::result_of<F(T)>::type>
+        template<typename F, typename _TRet = typename result_of<F(T)>::type>
         Linq<std::tuple<Linq<S, T>, std::unordered_set<_TRet> >, T> distinct(F transform) const
         {
             return Linq<std::tuple<Linq<S, T>, std::unordered_set<_TRet> >, T>(
@@ -417,7 +412,7 @@ namespace boolinq {
             return start;
         }
 
-        template<typename F, typename _TRet = typename std::result_of<F(T)>::type>
+        template<typename F, typename _TRet = typename result_of<F(T)>::type>
         _TRet sum(F transform) const
         {
             return aggregate<_TRet>(_TRet(), [transform](_TRet accumulator, T value) {
@@ -431,7 +426,7 @@ namespace boolinq {
             return sum([](T value) { return TRet(value); });
         }
 
-        template<typename F, typename _TRet = typename std::result_of<F(T)>::type>
+        template<typename F, typename _TRet = typename result_of<F(T)>::type>
         _TRet avg(F transform) const
         {
             int count = 0;


### PR DESCRIPTION
Normally, result_of deprecated in C++17 and removed in C++20, but some compilers have it even in trunk versions. For the sake of compatibility, use own result_of define instead of std.
If you decide not to support before C++17 in the future, just remove this definition and use invoke_result instead.