### PR TITLE
added boolinq::mut_from and modified for each to be able to mutate

### DIFF
--- a/test/ForEachTest.cpp
+++ b/test/ForEachTest.cpp
@@ -46,3 +46,60 @@ TEST(ForEach, ThreeIntsSum)
 
     EXPECT_EQ(60, sum);
 }
+
+
+
+TEST(ForEach, Mutation_Struct)
+{
+    struct _Human {
+
+        std::string name;
+        int age;
+
+        std::string toString() {
+
+            std:: stringstream s;
+            s << "- name : " << name << " age : " << age << " -";
+            return s.str();
+        }
+
+    };
+    _Human items[4] = { {"Albert",56},
+                        {"Heinrich",64},
+                        {"Renate",75},
+                        {"Anneliese",45} };
+
+    mut_from(items).for_each([](_Human& human) mutable {human.age += 1; });
+
+    EXPECT_EQ(items[0].age, 57);
+    EXPECT_EQ(items[1].age, 65);
+    EXPECT_EQ(items[2].age, 76);
+    EXPECT_EQ(items[3].age, 46);
+}
+TEST(ForEach, NonMutable_Struct)
+{
+    struct _Human {
+
+        std::string name;
+        int age;
+
+        std::string toString() {
+
+            std::stringstream s;
+            s << "- name : " << name << " age : " << age << " -";
+            return s.str();
+        }
+
+    };
+    _Human items[4] = { {"Albert",56},
+                        {"Heinrich",64},
+                        {"Renate",75},
+                        {"Anneliese",45} };
+
+    from(items).for_each([](_Human& human) mutable {human.age += 1; });
+
+    EXPECT_EQ(items[0].age, 56);
+    EXPECT_EQ(items[1].age, 64);
+    EXPECT_EQ(items[2].age, 75);
+    EXPECT_EQ(items[3].age, 45);
+}


### PR DESCRIPTION
Currently compiles only with MSVC!

Propeses a Solution for #55 by introducing a mut_from function.

To enable the normal from function to be able to create mutable Linq Objects would require extensive reworking of existing code.