### PR TITLE
Fixes the current issues with GitHub Action

### DIFF
--- a/.github/workflows/boolinq-test.yml
+++ b/.github/workflows/boolinq-test.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         cpp_version: [11, 14, 17, 20]
         compiler: [ {cpp: g++-9, c: gcc-9}, {cpp: g++-10, c: gcc-10}, {cpp: clang++-10, c: clang-10}, {cpp: clang++-11, c: clang-11}, {cpp: clang++-12, c: clang-12} ]
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Specifies the version of the Ubuntu environment for GitHub Action to use.

The configuration file was set to `ubuntu-latest` which has been updated by GitHub, breaking the configuration of this repository. I've corrected this issue by setting it to the version `ubuntu-20.04`.

Fixes #63 and the latest point found by @k06a in #76.